### PR TITLE
Remove unused Trouble keymap and redundant Treesitter ensure config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -73,7 +73,6 @@ vim.keymap.set('n', '<C-j>', '<C-w><C-j>', { desc = 'Move focus to the lower win
 vim.keymap.set('n', '<C-k>', '<C-w><C-k>', { desc = 'Move focus to the upper window' })
 
 
-vim.api.nvim_set_keymap('n', "<leader>et", ':TroubleToggle<CR>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('i', '<BS>', '<C-w>', { noremap = true, silent = true })
 -- vim.keymap.set('c', '<BS>', '<C-w>', { noremap = true, silent = true })
 -- the lua version above is not working for some strange reason, but this vim version does

--- a/lua/jeremiah/treesitter.lua
+++ b/lua/jeremiah/treesitter.lua
@@ -30,7 +30,6 @@ require('nvim-treesitter.configs').setup({
     auto_install = true,
     sync_install = false,
     ignore_install = {},
-    ensure_installed = ensure_installed_treesitter,
     highlight = {
         enable = true,
         disable = {},


### PR DESCRIPTION
## Summary
- remove the TroubleToggle keymap since the plugin is not installed
- drop the unused ensure_installed assignment from the Treesitter config

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e278c39a74832990690dda888cba88